### PR TITLE
fix typo

### DIFF
--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -545,7 +545,7 @@ class KPO():
         matrix based on an analytical model.
         ------------------------------------------------------------------ '''
         if phi_cov is not None:
-            self.phi_cov = kp_cov
+            self.phi_cov = phi_cov
         else:
             try:
                 _ = self.CVIS[0]

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -108,7 +108,7 @@ class KPO():
         # covariance?
         # -----------
         try:
-            test = hdul['KP_COV']
+            test = hdul['KP-COV']
             self.kp_cov = test.data
             print("Covariance data available and loaded")
         except KeyError:


### PR DESCRIPTION
This pull request fixes a typo in the code which generates a kpo from a fits file. The original code had a typo in the fits header which checked for the presence of a covariance matrix in the fits file. This prevented the covariance matrix from being loaded even if the file contained it. I changed a "_" was changed to a "-" to fix this.