### PR TITLE
Extra update after merging jwst-kpi additions

### DIFF
--- a/src/xara/kpi.py
+++ b/src/xara/kpi.py
@@ -144,12 +144,8 @@ class KPI(object):
             print("4. KPI(array=[[x1, y1], [x2, y2], ..., [xn, yn]]) ")
             return None
 
-    # =========================================================================
-    def __del__(self):
-        print("%s deleted " % (repr(self),))
 
     # =========================================================================
-
     def load_aperture_model(self, fname=None, data=None):
         ''' ------------------------------------------------------------------
         Create a virtual aperture model from the coordinates provided in a

--- a/src/xara/kpi.py
+++ b/src/xara/kpi.py
@@ -646,21 +646,22 @@ class KPI(object):
         blm_hdu.header.add_comment("Baseline Mapping Matrix")
         blm_hdu.header['EXTNAME'] = 'BLM-MAT'
 
-        # Pupil mask HDU
+        # compile HDU list and save
+        # -------------------------
+        self.hdul = fits.HDUList([pri_hdu, tb1_hdu, tb2_hdu, kpm_hdu, blm_hdu])
+
+        # Pupil mask HDU if it exists
         if self.pupil_mask is not None:
             mask_hdu = fits.ImageHDU(self.pupil_mask)
             mask_hdu.header.add_comment("Pupil mask used to create aperture model")
             mask_hdu.header["PUPLSCAL"] = (self.pupil_scale or 0.0, "Pupil scale of the mask [m]")
             mask_hdu.header["EXTNAME"] = "PUPIL-MASK"
+            self.hdul.append(mask_hdu)
 
-        # compile HDU list and save
-        # -------------------------
-
-        self.hdul = fits.HDUList([pri_hdu, tb1_hdu, tb2_hdu, kpm_hdu, blm_hdu])
 
         if fname is not None:
             self.hdul.writeto(fname, overwrite=True)
-        return(self.hdul)
+        return self.hdul
 
     # =========================================================================
     # =========================================================================

--- a/src/xara/kpo.py
+++ b/src/xara/kpo.py
@@ -171,9 +171,6 @@ class KPO():
         except KeyError:
             print("No covariance data available")
 
-    # =========================================================================
-    def __del__(self):
-        print("%s deleted" % (repr(self),))
 
     # =========================================================================
     def __str__(self):

--- a/src/xara/kpo.py
+++ b/src/xara/kpo.py
@@ -110,7 +110,7 @@ class KPO():
                 msg += f"Underlying error: '{type(e).__name__}: {e}'"
                 raise ValueError(msg)
         elif input_format.upper() == "KPFITS":
-            self._get_kpo_kpfits(hdul)
+            self.get_kpo_kpfits(hdul)
         else:
             raise ValueError(f"Unknown input format {input_format}")
 
@@ -118,7 +118,7 @@ class KPO():
         # ---
         hdul.close()
 
-    def _get_kpo_kpfits(self, hdul: fits.HDUList):
+    def get_kpo_kpfits(self, hdul: fits.HDUList):
         # TODO: Support multi-lambda (axis=1 in numpy), not sure xara does that yet?
         # TODO: Support MJDATE
         self.KPDT.append(hdul['KP-DATA'].data[:, 0])

--- a/src/xara/kpo.py
+++ b/src/xara/kpo.py
@@ -73,6 +73,7 @@ class KPO():
 
 
         self.CWAVEL = []  # image/cube central wavelength
+        self.BWIDTH = []  # image/cube bandwidth
         self.PSCALE = []  # image/cube plate scale
         self.WRAD = []    # data apodization function radius
         self.WTYPE = []   # data apodization function type
@@ -474,7 +475,7 @@ class KPO():
 
     # =========================================================================
     # =========================================================================
-    def extract_KPD_single_cube(self, cube, pscale, cwavel,
+    def extract_KPD_single_cube(self, cube, pscale, cwavel, bwidth=None,
                                 detpa=0.0, mjdate=0.0, target="NO_NAME",
                                 recenter=False, wrad=None, wtype="sgauss",
                                 method="LDFT1"):
@@ -519,6 +520,7 @@ class KPO():
         self.KPDT.append(_kpdt)
 
         self.CWAVEL.append(cwavel)
+        self.BWIDTH.append(bwidth)
         self.PSCALE.append(pscale)
         self.WRAD.append(wrad)
         self.WTYPE.append(wtype)

--- a/src/xara/kpo.py
+++ b/src/xara/kpo.py
@@ -208,8 +208,13 @@ class KPO():
             msg += "-> CWAVEL = %.2f microns\n" % (self.CWAVEL[ii] * 1e6,)
             msg += "-> PSCALE = %.2f mas/pixel\n" % (self.PSCALE[ii],)
             msg += "-> DETPA = %.2f (degrees)\n" % (self.DETPA[ii])
-            if self.MJDATE[ii][0] != 0.0:
-                myd = Time(val=self.MJDATE[ii][0], format="mjd")
+            mjdi = self.MJDATE[ii]
+            try:
+                mjdi = mjdi[0]
+            except TypeError:
+                pass
+            if mjdi != 0.0:
+                myd = Time(val=mjdi, format="mjd")
                 msg += "-> MJDATE = %s\n" % myd.to_value("iso")
 
         msg += "-" * 40 + "\n"


### PR DESCRIPTION
Here are a few updates on top of @fmartinache's latest changes and the JWST additions:

- Save the pupil mask HDU when it exists in `package_as_fits()`
- Make `get_kpo_kpfits` public (removing leading underscore) so users can easily add files to a KPO object
- Don't print anything when the KPO object is deleted. Very few Python structures do this so removing it makes KPO closer to standard objects. `__del__()` runs automatically in many contexts so it can be confusing/overly verbose for users.
- Enable creating a KPO from multiple KPFITS files through `KPO.from_kpfits_list()`