### PR TITLE
Add and `axis` argument to `KPO.average()`

### DIFF
--- a/src/xara/kpo.py
+++ b/src/xara/kpo.py
@@ -1317,7 +1317,7 @@ class KPO():
         """
         kpo = self.copy()
         nsets = len(kpo.KPDT)
-        if all([d.shape[0] == 1 for d in kpo.KPDT]):
+        if all([d.shape[0] == 1 for d in kpo.KPDT]) and axis == "ints":
             return kpo
 
         has_errors = len(kpo.KPSIG) > 0 and all([sig is not None for sig in kpo.KPSIG])

--- a/tests/test_kpo.py
+++ b/tests/test_kpo.py
@@ -167,3 +167,7 @@ def test_kpo_average(pharo_kpo: KPO, data_dir: Path):
     with pytest.warns(UserWarning, match="Dataset"):
         avg_kpo_frame = pharo_kpo_frame.average()
     np.testing.assert_equal(avg_kpo_frame.KPDT, pharo_kpo_frame.KPDT)
+
+    avg_kpo_frame_both = pharo_kpo_frame.average(axis="both")
+    np.testing.assert_allclose(avg_kpo.KPDT, avg_kpo_frame_both.KPDT)
+    np.testing.assert_allclose(avg_kpo.KPSIG, avg_kpo_frame_both.KPSIG)


### PR DESCRIPTION
This allows one to average only the integrations in each dataset (default behaviour) or all integrations across all datasets (useful for multiple cubes of the same target).